### PR TITLE
Hotfix PlatformIO build

### DIFF
--- a/tools/platformio/platformio-build.py
+++ b/tools/platformio/platformio-build.py
@@ -259,18 +259,22 @@ env.Append(
 
 # For boards supporting a USB stack: Include it.
 if not board_config.get("build.spl_series").lower().startswith("gd32e23"):
-    if isdir(join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbd_driver")):
+    if isdir(join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbd_library")):
         env.Append(
             CPPPATH=[
-                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbd_driver", "Include"),
-                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbd_driver", "Source"),
+                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbd_library", "device", "Include"),
+                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbd_library", "device", "Source"),
+                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbd_library", "usbd", "Include"),
+                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbd_library", "usbd", "Source"),
             ]
         )
-    if isdir(join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbfs_driver")):
+    if isdir(join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbfs_driver")) and False:
         env.Append(
             CPPPATH=[
-                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbfs_driver", "Include"),
-                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbfs_driver", "Source"),
+                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbfs_driver", "driver", "Include"),
+                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbfs_driver", "driver", "Source"),
+                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbfs_driver", "core", "Include"),
+                join(FRAMEWORK_DIR, "system", spl_series + "_firmware", spl_series + "_usbfs_driver", "core", "Source"),
             ]
         )
 


### PR DESCRIPTION
Folder names and structure has changed for the USB library, PlatformIO builder scripts must be updated accordingly.

Only does that for the USBD library correctly, not USBFS, otherwise we get conflicts..

Tested with `platformio.ini`

```ini
[env]
platform = https://github.com/CommunityGD32Cores/platform-gd32.git
platform_packages = 
    framework-arduinogd32@https://github.com/bjc/ArduinoCore-GD32.git#bjc/pluggable-usb-support
monitor_speed = 115200

[env:genericGD32F303CC]
board = genericGD32F303CC
framework = arduino
build_flags =
    -DUSB_VID=0x1209
    -DUSB_PID=0x2301
    "-DUSB_MANUFACTURER=\"Arduino\""
    "-DUSB_PRODUCT=\"USB Test\""
debug_init_cmds =
  target extended-remote $DEBUG_PORT
  $INIT_BREAK
  monitor halt
  monitor init
  monitor resume
build_type = debug
```

The bit at the bottom is to make debug as "Attach to Running Target" instead of trying to flash the firmware again. Handy for just letting the firmware run, then attach and see if it hung up in some `while(1){}` loop (which I inserted in e.g. the ringbuffer routines to see if edge conditions were experienced) 